### PR TITLE
Corrects the selector in the kube service

### DIFF
--- a/kube/service.yml
+++ b/kube/service.yml
@@ -11,4 +11,4 @@ spec:
     port: 443
     targetPort: 10443
   selector:
-    name: cop-data-api-spec-spec
+    name: cop-data-api-spec


### PR DESCRIPTION
Removes a typo from the value of the selector (that was causing 503 http errors)